### PR TITLE
[example-bug-fix] Corrected draggableHandle configuration

### DIFF
--- a/test/examples/5-static-elements.jsx
+++ b/test/examples/5-static-elements.jsx
@@ -24,7 +24,7 @@ export default class StaticElementsLayout extends React.PureComponent {
         className="layout"
         onLayoutChange={this.onLayoutChange}
         rowHeight={30}
-        draggableHandle: ".react-grid-dragHandleExample"
+        draggableHandle=".react-grid-dragHandleExample"
       >
         <div key="1" data-grid={{ x: 0, y: 0, w: 2, h: 3 }}>
           <span className="text">1</span>

--- a/test/examples/5-static-elements.jsx
+++ b/test/examples/5-static-elements.jsx
@@ -24,6 +24,7 @@ export default class StaticElementsLayout extends React.PureComponent {
         className="layout"
         onLayoutChange={this.onLayoutChange}
         rowHeight={30}
+        draggableHandle: ".react-grid-dragHandleExample"
       >
         <div key="1" data-grid={{ x: 0, y: 0, w: 2, h: 3 }}>
           <span className="text">1</span>
@@ -40,8 +41,7 @@ export default class StaticElementsLayout extends React.PureComponent {
             x: 8,
             y: 0,
             w: 4,
-            h: 3,
-            draggableHandle: ".react-grid-dragHandleExample"
+            h: 3
           }}
         >
           <span className="text">


### PR DESCRIPTION
- Set `draggableHandle: ".react-grid-dragHandleExample"` as a `ReactGridLayout` property instead of data-grid property

Thanks for submitting a pull request to RGL!

Please reference an open issue. If one has not been created, please create one along with a failing
example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
